### PR TITLE
feat: show pr number

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -33,6 +33,7 @@ if (pr) {
 const store = useStore({
   serializedState: location.hash.slice(1),
   userOptions: initialUserOptions,
+  pr
 })
 
 if (pr) {
@@ -49,6 +50,11 @@ if (pr) {
 
 store.init().then(() => (loading = false))
 
+if (!store.pr) {
+  if (store.userOptions.value.styleSource) {
+    store.pr = store.userOptions.value.styleSource.split('-', 2)[1]
+  }
+}
 // eslint-disable-next-line no-console
 console.log('Store:', store)
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -69,6 +69,7 @@ async function copyLink() {
         <span>Element Plus Playground</span>
         <el-tag size="small">{{ appVersion }}</el-tag>
         <el-tag size="small">repl v{{ replVersion }}</el-tag>
+        <el-tag size="small" v-if="store.pr">pr {{store.pr}}</el-tag>
       </div>
     </h1>
 

--- a/src/composables/store.ts
+++ b/src/composables/store.ts
@@ -11,6 +11,7 @@ export interface Initial {
   serializedState?: string
   versions?: Versions
   userOptions?: UserOptions
+  pr?: string | null
 }
 export type VersionKey = 'vue' | 'elementPlus'
 export type Versions = Record<VersionKey, string>
@@ -258,6 +259,7 @@ export const useStore = (initial: Initial) => {
     serialize,
     setVersion,
     toggleNightly,
+    pr: initial.pr
   }
 }
 


### PR DESCRIPTION
When the default playground is opened at the same time and the corresponding pr preview is compared, the corresponding pr number will be displayed, which will be more friendly.