### PR TITLE
fix: preview failed when the `Element Plus` version is less than 2.2.0

### DIFF
--- a/src/template/element-plus.js
+++ b/src/template/element-plus.js
@@ -22,5 +22,5 @@ export function loadStyle() {
       document.body.append(link)
     })
   })
-  return Promise.all(styles)
+  return Promise.allSettled(styles)
 }


### PR DESCRIPTION
Missing the `theme-chalk/dark/css-vars.css` file.

![image](https://github.com/user-attachments/assets/1748f848-82bc-4514-a08e-5320254fddb1)
