### PR TITLE
fix: import element bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint": "eslint --cache --max-warnings 0 .",
     "lint:fix": "pnpm run lint --fix",
     "typecheck": "vue-tsc --noEmit",
-    "release": "bumpp"
+    "release": "bumpp",
+    "format": "prettier --write --cache ."
   },
   "dependencies": {
     "@unocss/reset": "^0.62.3",

--- a/src/composables/store.ts
+++ b/src/composables/store.ts
@@ -55,7 +55,7 @@ export const useStore = (initial: Initial) => {
   const userOptions: UserOptions = pr
     ? {
         showHidden: true,
-        styleSource: `https://preview-${pr}-element-plus.surge.sh/bundle/index.css`,
+        styleSource: `https://preview-${pr}-element-plus.surge.sh/bundle/dist/index.css`,
       }
     : {}
   const hideFile = !IS_DEV && !userOptions.showHidden
@@ -66,7 +66,7 @@ export const useStore = (initial: Initial) => {
     if (pr)
       importMap = mergeImportMap(importMap, {
         imports: {
-          'element-plus': `https://preview-${pr}-element-plus.surge.sh/bundle/index.full.min.mjs`,
+          'element-plus': `https://preview-${pr}-element-plus.surge.sh/bundle/dist/index.full.min.mjs`,
           'element-plus/': 'unsupported',
         },
       })

--- a/src/composables/store.ts
+++ b/src/composables/store.ts
@@ -49,6 +49,8 @@ export const useStore = (initial: Initial) => {
     saved?._o?.styleSource?.split('-', 2)[1]
   const oldPrUrl = `https://preview-${pr}-element-plus.surge.sh/bundle`
   const prUrl = ref(`${oldPrUrl}/dist`)
+ 
+  //NOTE: remove fetch bundle if no pr's has old bundle (prev 01/13/2025)
   onBeforeMount(() => {
     if (!pr) return
     fetch(prUrl.value).then((res) => {

--- a/src/composables/store.ts
+++ b/src/composables/store.ts
@@ -47,9 +47,7 @@ export const useStore = (initial: Initial) => {
   const pr =
     new URLSearchParams(location.search).get('pr') ||
     saved?._o?.styleSource?.split('-', 2)[1]
-  const oldPrUrl = `https://preview-${pr}-element-plus.surge.sh/bundle`
-  // 19668 is the latest pr that have old bundle
-  const prUrl = pr && +pr >= 19668 ? `${oldPrUrl}/dist` : oldPrUrl
+  const prUrl = `https://preview-${pr}-element-plus.surge.sh/bundle/dist`
 
   const versions = reactive<Versions>({
     vue: 'latest',
@@ -129,16 +127,17 @@ export const useStore = (initial: Initial) => {
   )
 
   function generateElementPlusCode(version: string, styleSource?: string) {
-    const pkg = nightly.value ? '@element-plus/nightly' : 'element-plus'
-    const darkRoute = '/theme-chalk/dark/css-vars.css'
     const style = styleSource
       ? styleSource.replace('#VERSION#', version)
-      : genCdnLink(pkg, version, '/dist/index.css')
-
-    const darkStyle =
-      !!pr && prUrl.endsWith('/bundle')
-        ? genCdnLink(pkg, 'latest', darkRoute)
-        : style.replace('/dist/index.css', darkRoute)
+      : genCdnLink(
+          nightly.value ? '@element-plus/nightly' : 'element-plus',
+          version,
+          '/dist/index.css',
+        )
+    const darkStyle = style.replace(
+      '/dist/index.css',
+      '/theme-chalk/dark/css-vars.css',
+    )
     return elementPlusCode
       .replace('#STYLE#', style)
       .replace('#DARKSTYLE#', darkStyle)


### PR DESCRIPTION
For dark theme:
- Previous bundle pr's get dark theme from latest element plus bundle because it is not included in bundle
- New bundle pr's (new pr or updated pr) will get directly dark theme from bundle

Should include types changed from new pr's bundle (https://github.com/element-plus/element-plus/issues/19223)

**Note**: We open a new network connection to see if the bundle is a new or old one. This can be the migration until we assume all pr's has new bundle (maybe in 1-2 years)

cc @btea (dont know if you have notification in this repo, sorry if you already seen this pr)