### PR TITLE
Fix/user version select

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,13 +54,14 @@ const handleKeydown = (evt: KeyboardEvent) => {
 }
 
 // persist state
-watchEffect(() =>
+watchEffect(() => {
+  store.typescriptVersion
   history.replaceState(
     {},
     '',
     `${location.origin}${location.pathname}#${store.serialize()}`,
-  ),
-)
+  )
+})
 
 const refreshPreview = () => {
   replRef.value?.reload()

--- a/src/composables/store.ts
+++ b/src/composables/store.ts
@@ -28,6 +28,9 @@ export type Versions = Record<VersionKey, string>
 export interface UserOptions {
   styleSource?: string
   showHidden?: boolean
+  vueVersion?: string
+  tsVersion?: string
+  elVersion?: string
 }
 export type SerializeState = Record<string, string> & {
   _o?: UserOptions
@@ -50,15 +53,17 @@ export const useStore = (initial: Initial) => {
   const prUrl = `https://preview-${pr}-element-plus.surge.sh/bundle/dist`
 
   const versions = reactive<Versions>({
-    vue: 'latest',
-    elementPlus: pr ? 'preview' : 'latest',
-    typescript: 'latest',
+    vue: saved?._o?.vueVersion ?? 'latest',
+    elementPlus: pr
+      ? 'preview'
+      : saved?._o?.elVersion ?? 'latest',
+    typescript: saved?._o?.tsVersion ?? 'latest',
   })
   const userOptions: UserOptions = pr
     ? {
-        showHidden: true,
-        styleSource: `${prUrl}/index.css`,
-      }
+      showHidden: true,
+      styleSource: `${prUrl}/index.css`,
+    }
     : {}
 
   const hideFile = !IS_DEV && !userOptions.showHidden
@@ -130,10 +135,10 @@ export const useStore = (initial: Initial) => {
     const style = styleSource
       ? styleSource.replace('#VERSION#', version)
       : genCdnLink(
-          nightly.value ? '@element-plus/nightly' : 'element-plus',
-          version,
-          '/dist/index.css',
-        )
+        nightly.value ? '@element-plus/nightly' : 'element-plus',
+        version,
+        '/dist/index.css',
+      )
     const darkStyle = style.replace(
       '/dist/index.css',
       '/theme-chalk/dark/css-vars.css',
@@ -210,13 +215,16 @@ export const useStore = (initial: Initial) => {
   async function setVersion(key: VersionKey, version: string) {
     switch (key) {
       case 'vue':
+        userOptions.vueVersion = version
         await setVueVersion(version)
         break
       case 'elementPlus':
         versions.elementPlus = version
+        userOptions.elVersion = version
         break
       case 'typescript':
         store.typescriptVersion = version
+        userOptions.tsVersion = version
         break
     }
   }


### PR DESCRIPTION
- 修复用户选择的版本，分享之后打开链接不能默认选中的问题。
[复现地址](https://element-plus.run/) ，选择版本号之后，点击分享按钮，不能正常携带用户选择的版本号。
![image](https://github.com/user-attachments/assets/93dc3ca6-33d3-493c-a335-1c478884c231)
