### PR TITLE
Revert "chore: upgrade pnpm to 10.13.1 (#322)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "element-plus-playground",
   "version": "2.5.1",
-  "packageManager": "pnpm@10.13.1",
+  "packageManager": "pnpm@10.2.0",
   "description": "Element Plus Playground",
   "type": "module",
   "engines": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,0 @@
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-  - vue-demi


### PR DESCRIPTION
This reverts commit 1bad099103a9e57cef868bec434bf007ff1c903a.

This commit will cause the preview to fail.