### PR TITLE
fix: output button is not visible on mobile devices

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -121,6 +121,12 @@ const refreshPreview = () => {
 }
 
 watch(autoSave, setAutoSaveState)
+
+const setVH = () => {
+  document.documentElement.style.setProperty('--vh', `${window.innerHeight}px`)
+}
+useEventListener('resize', setVH)
+setVH()
 </script>
 
 <template>
@@ -139,6 +145,7 @@ watch(autoSave, setAutoSaveState)
       :store="store"
       :editor="Monaco"
       :preview-options="previewOptions"
+      auto-resize
       @keydown="handleKeydown"
     />
     <Teleport defer to=".vue-repl .right">
@@ -166,7 +173,7 @@ body {
 }
 
 .vue-repl {
-  height: calc(100vh - var(--nav-height)) !important;
+  height: calc(var(--vh) - var(--nav-height)) !important;
 }
 
 .vue-repl .right {


### PR DESCRIPTION


<details><summary>Pictures</summary>
Before

<img width="1179" height="2556" alt="IMG_3013" src="https://github.com/user-attachments/assets/653cd3ac-7dbc-47db-a535-bfd11b516241" />

After

<img width="1179" height="2556" alt="IMG_3012" src="https://github.com/user-attachments/assets/3b2b8dca-0436-417c-a7e1-f450749063dd" />
</details> 
